### PR TITLE
Fix: #valid_coordinate to #valid_placement?

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -8,14 +8,16 @@ class Board
     @cells = {}
     ("A".."D").each do |letter|
       (1..4).each do |number|
-       cell_key = "#{letter}#{number}"
-       @cells[cell_key] = Cell.new(cell_key)
+        cell_key = "#{letter}#{number}"
+        @cells[cell_key] = Cell.new(cell_key)
       end
     end
   end
 
-  def valid_coordinate?(coordinates)
-    @cells.key?(coordinates)
+
+
+  def valid_coordinate?(coordinate)
+    @cells.key?(coordinate)
   end
 
   def ascending?(data)
@@ -25,6 +27,13 @@ class Board
   def valid_placement?(ship, coordinates)
     return false unless coordinates.length == ship.length
     
+    new_coordinates = coordinates.map do |coordinate|
+    valid_coordinate?(coordinate)
+    end
+
+    return false if !new_coordinates.all?
+
+
     letters = coordinates.map { |coord| coord[0]}
     numbers = coordinates.map { |coord| coord[1..-1].to_i}
     

--- a/lib/board.rb
+++ b/lib/board.rb
@@ -14,10 +14,15 @@ class Board
     end
   end
 
-
-
   def valid_coordinate?(coordinate)
     @cells.key?(coordinate)
+  end
+
+  def valid_coordinates?(coordinates)
+      new_coordinates = coordinates.map do |coordinate|
+      valid_coordinate?(coordinate)
+      end
+      new_coordinates.all?
   end
 
   def ascending?(data)
@@ -26,13 +31,7 @@ class Board
 
   def valid_placement?(ship, coordinates)
     return false unless coordinates.length == ship.length
-    
-    new_coordinates = coordinates.map do |coordinate|
-    valid_coordinate?(coordinate)
-    end
-
-    return false if !new_coordinates.all?
-
+    return false unless valid_coordinates?(coordinates) == true
 
     letters = coordinates.map { |coord| coord[0]}
     numbers = coordinates.map { |coord| coord[1..-1].to_i}

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Board do
     end
   end
 
-  describe "#valid_placement?(ship, coordinates)" do
+  describe "#valid_coordinate?(coordinates)" do
     it "can validate coordinate" do
       board = Board.new
 
@@ -57,7 +57,15 @@ RSpec.describe Board do
 
     it "returns true if placement is valid" do
       expect(@board.valid_placement?(@submarine, ["A1", "A2"])).to be(true)
+      expect(@board.valid_placement?(@submarine, ["E1", "E2"])).to be(false)
       expect(@board.valid_placement?(@cruiser, ["B1", "C1", "D1"])).to be(true)
     end
+
+    it "returns false if placement coordinates are invalid" do
+      expect(@board.valid_placement?(@submarine, ["E1", "E2"])).to be(false)
+      expect(@board.valid_placement?(@cruiser, ["C1", "D1", "E1"])).to be(false)
+    end
+
+
   end
 end

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Board do
     end
   end
 
-  describe "#valid_coordinate?(coordinates)" do
+  describe "#valid_coordinate?(coordinate)" do
     it "can validate coordinate" do
       board = Board.new
 
@@ -28,6 +28,16 @@ RSpec.describe Board do
       expect(board.valid_coordinate?("A5")).to be(false)
       expect(board.valid_coordinate?("E1")).to be(false)
       expect(board.valid_coordinate?("A22")).to be(false)
+    end
+  end
+
+  describe "#valid_coordinates?(coordinates)" do
+    it "can validate coordinates" do
+      board = Board.new
+
+      expect(board.valid_coordinates?(["A1", "B2", "C4"])).to be(true)
+      
+      expect(board.valid_coordinates?(["A3", "A5", "A1"])).to be(false)
     end
   end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -36,7 +36,6 @@ RSpec.describe Board do
       board = Board.new
 
       expect(board.valid_coordinates?(["A1", "B2", "C4"])).to be(true)
-      
       expect(board.valid_coordinates?(["A3", "A5", "A1"])).to be(false)
     end
   end


### PR DESCRIPTION
This feature will add the #valid_coordinate method to the #valid placement? method to ensure it only returns true if each coordinate is also valid as well. 